### PR TITLE
View specs and n+1 problems

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,7 +5,7 @@ class PostsController < ApplicationController
   end
 
   def show
-    @post = Post.find(params[:id])
+    @post = Post.includes(:user).find(params[:id])
     @user = User.find(params[:user_id])
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,8 +5,8 @@ class PostsController < ApplicationController
   end
 
   def show
-    @post = Post.includes(:user).find(params[:id])
     @user = User.find(params[:user_id])
+    @post = Post.includes(:comments).find(params[:id])
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :show, only: [:show]
   def index
     @users = User.all
   end

--- a/spec/features/post_spec.rb
+++ b/spec/features/post_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.feature "Posts", type: :feature do
+  pending "add some scenarios (or delete) #{__FILE__}"
+end

--- a/spec/features/post_spec.rb
+++ b/spec/features/post_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.feature "Posts", type: :feature do
-  pending "add some scenarios (or delete) #{__FILE__}"
-end

--- a/spec/features/post_spec.rb
+++ b/spec/features/post_spec.rb
@@ -1,51 +1,52 @@
 require 'rails_helper'
 
-RSpec.feature "Posts", type: :feature do
-    before(:all) do
-        @first_user = User.create(name: 'Integration test', photo: 'http://twitter.com', bio: 'test for User')
-        @post1 = Post.create(title: 'Rspec test 1', text: 'rspec test for post', author_id: @first_user.id)
-        @post2 = Post.create(title: 'Rspec test 2', text: 'rspec test for post', author_id: @first_user.id)
-        @post3 = Post.create(title: 'Rspec test 3', text: 'rspec test for post', author_id: @first_user.id)
-    end
-    
-    describe 'Post index page test' do
-        scenario 'Should show the title ' do
-        visit "/users/#{@first_user.id}/posts"
-        expect(page).to have_content(@post1.title)
-        end
-    
-        scenario 'Should show the text' do
-        visit "/users/#{@first_user.id}/posts"
-        expect(page).to have_content(@post1.text)
-        end
-    
-        scenario 'Should show the author' do
-        visit "/users/#{@first_user.id}/posts"
-        expect(page).to have_content(@first_user.name)
-        end
-    
-        scenario 'should redirect to post\'s page' do
-        visit "/users/#{@first_user.id}"
-        click_on @post1.title
-        expect(page).to have_current_path("/users/#{@first_user.id}/posts/#{@post1.id}")
-        end
+# rubocop:disable Metrics/BlockLength
+RSpec.feature 'Posts', type: :feature do
+  before(:all) do
+    @first_user = User.create(name: 'Integration test', photo: 'http://twitter.com', bio: 'test for User')
+    @post1 = Post.create(title: 'Rspec test 1', text: 'rspec test for post', author_id: @first_user.id)
+    @post2 = Post.create(title: 'Rspec test 2', text: 'rspec test for post', author_id: @first_user.id)
+    @post3 = Post.create(title: 'Rspec test 3', text: 'rspec test for post', author_id: @first_user.id)
+  end
+
+  describe 'Post index page test' do
+    scenario 'Should show the title ' do
+      visit "/users/#{@first_user.id}/posts"
+      expect(page).to have_content(@post1.title)
     end
 
-    describe 'Post show page test' do
-        scenario 'Should show the title ' do
-        visit "users/#{@first_user.id}/posts/#{@post1.id}"
-        expect(page).to have_content(@post1.title)
-        end
-    
-        scenario 'Should show the text' do
-        visit "users/#{@first_user.id}/posts/#{@post1.id}"
-        expect(page).to have_content(@post1.text)
-        end
-    
-        scenario 'Should show the author' do
-        visit "users/#{@first_user.id}/posts/#{@post1.id}"
-        expect(page).to have_content(@first_user.name)
-        end
+    scenario 'Should show the text' do
+      visit "/users/#{@first_user.id}/posts"
+      expect(page).to have_content(@post1.text)
     end
 
+    scenario 'Should show the author' do
+      visit "/users/#{@first_user.id}/posts"
+      expect(page).to have_content(@first_user.name)
+    end
+
+    scenario 'should redirect to post\'s page' do
+      visit "/users/#{@first_user.id}"
+      click_on @post1.title
+      expect(page).to have_current_path("/users/#{@first_user.id}/posts/#{@post1.id}")
+    end
+  end
+
+  describe 'Post show page test' do
+    scenario 'Should show the title ' do
+      visit "users/#{@first_user.id}/posts/#{@post1.id}"
+      expect(page).to have_content(@post1.title)
+    end
+
+    scenario 'Should show the text' do
+      visit "users/#{@first_user.id}/posts/#{@post1.id}"
+      expect(page).to have_content(@post1.text)
+    end
+
+    scenario 'Should show the author' do
+      visit "users/#{@first_user.id}/posts/#{@post1.id}"
+      expect(page).to have_content(@first_user.name)
+    end
+  end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/features/post_spec.rb
+++ b/spec/features/post_spec.rb
@@ -6,7 +6,46 @@ RSpec.feature "Posts", type: :feature do
         @post1 = Post.create(title: 'Rspec test 1', text: 'rspec test for post', author_id: @first_user.id)
         @post2 = Post.create(title: 'Rspec test 2', text: 'rspec test for post', author_id: @first_user.id)
         @post3 = Post.create(title: 'Rspec test 3', text: 'rspec test for post', author_id: @first_user.id)
-        @post4 = Post.create(title: 'Rspec test 4', text: 'rspec test for post', author_id: @first_user.id)
     end
     
+    describe 'Post index page test' do
+        scenario 'Should show the title ' do
+        visit "/users/#{@first_user.id}/posts"
+        expect(page).to have_content(@post1.title)
+        end
+    
+        scenario 'Should show the text' do
+        visit "/users/#{@first_user.id}/posts"
+        expect(page).to have_content(@post1.text)
+        end
+    
+        scenario 'Should show the author' do
+        visit "/users/#{@first_user.id}/posts"
+        expect(page).to have_content(@first_user.name)
+        end
+    
+        scenario 'should redirect to post\'s page' do
+        visit "/users/#{@first_user.id}/posts"
+        click_on @post1.title
+        expect(page).to have_current_path("users/#{@first_user.id}/posts/#{@post1.id}")
+        end
+    end
+
+    describe 'Post show page test' do
+        scenario 'Should show the title ' do
+        visit "users/#{@first_user.id}/posts/#{@post1.id}"
+        expect(page).to have_content(@post1.title)
+        end
+    
+        scenario 'Should show the text' do
+        visit "users/#{@first_user.id}/posts/#{@post1.id}"
+        expect(page).to have_content(@post1.text)
+        end
+    
+        scenario 'Should show the author' do
+        visit "users/#{@first_user.id}/posts/#{@post1.id}"
+        expect(page).to have_content(@first_user.name)
+        end
+    end
+
 end

--- a/spec/features/post_spec.rb
+++ b/spec/features/post_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.feature "Posts", type: :feature do
+    before(:all) do
+        @first_user = User.create(name: 'Integration test', photo: 'http://twitter.com', bio: 'test for User')
+        @post1 = Post.create(title: 'Rspec test 1', text: 'rspec test for post', author_id: @first_user.id)
+        @post2 = Post.create(title: 'Rspec test 2', text: 'rspec test for post', author_id: @first_user.id)
+        @post3 = Post.create(title: 'Rspec test 3', text: 'rspec test for post', author_id: @first_user.id)
+        @post4 = Post.create(title: 'Rspec test 4', text: 'rspec test for post', author_id: @first_user.id)
+    end
+    
+end

--- a/spec/features/post_spec.rb
+++ b/spec/features/post_spec.rb
@@ -25,9 +25,9 @@ RSpec.feature "Posts", type: :feature do
         end
     
         scenario 'should redirect to post\'s page' do
-        visit "/users/#{@first_user.id}/posts"
+        visit "/users/#{@first_user.id}"
         click_on @post1.title
-        expect(page).to have_current_path("users/#{@first_user.id}/posts/#{@post1.id}")
+        expect(page).to have_current_path("/users/#{@first_user.id}/posts/#{@post1.id}")
         end
     end
 

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.feature "Users", type: :feature do
+  pending "add some scenarios (or delete) #{__FILE__}"
+end

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
-RSpec.feature "Users", type: :feature do
+# rubocop:disable Metrics/BlockLength
+RSpec.feature 'Users', type: :feature do
   before(:all) do
     @first_user = User.create(name: 'Integration test', photo: 'http://twitter.com', bio: 'test for User')
     @post1 = Post.create(title: 'Rspec test 1', text: 'rspec test for post', author_id: @first_user.id)
@@ -62,6 +63,5 @@ RSpec.feature "Users", type: :feature do
       expect(page).to have_current_path(user_post_path(@first_user, @post2))
     end
   end
-
-  
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -1,5 +1,37 @@
 require 'rails_helper'
 
 RSpec.feature "Users", type: :feature do
-  pending "add some scenarios (or delete) #{__FILE__}"
+  before(:all) do
+    @first_user = User.create(name: 'Integration test', photo: 'http://twitter.com', bio: 'test for User')
+    @post1 = Post.create(title: 'Rspec test 1', text: 'rspec test for post', user: @first_user)
+    @post2 = Post.create(title: 'Rspec test 2', text: 'rspec test for post', user: @first_user)
+    @post3 = Post.create(title: 'Rspec test 3', text: 'rspec test for post', user: @first_user)
+    @post4 = Post.create(title: 'Rspec test 4', text: 'rspec test for post', user: @first_user)
+  end
+
+  describe 'User index page test' do
+    scenario 'Should show the username ' do
+      visit users_path
+      expect(page).to have_content(@first_user.name)
+    end
+
+    scenario 'Should show the profile picture' do
+      visit users_path
+      expect(page).to have_selector("img[src='#{@first_user.photo}']")
+    end
+
+    scenario 'Should show the Number of posts' do
+      visit users_path
+      expect(page).to have_text('Number of posts: 4')
+    end
+
+    scenario 'should redirect to user\'s page' do
+      @second_user = User.create(name: 'Messi', photo: 'http://google.com', bio: 'test for redirecting')
+      visit users_path
+      click_on @second_user.name
+      expect(page).to have_current_path(user_path(@second_user))
+    end
+  end
+
+  
 end

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 RSpec.feature "Users", type: :feature do
   before(:all) do
     @first_user = User.create(name: 'Integration test', photo: 'http://twitter.com', bio: 'test for User')
-    @post1 = Post.create(title: 'Rspec test 1', text: 'rspec test for post', user: @first_user)
-    @post2 = Post.create(title: 'Rspec test 2', text: 'rspec test for post', user: @first_user)
-    @post3 = Post.create(title: 'Rspec test 3', text: 'rspec test for post', user: @first_user)
-    @post4 = Post.create(title: 'Rspec test 4', text: 'rspec test for post', user: @first_user)
+    @post1 = Post.create(title: 'Rspec test 1', text: 'rspec test for post', author_id: @first_user.id)
+    @post2 = Post.create(title: 'Rspec test 2', text: 'rspec test for post', author_id: @first_user.id)
+    @post3 = Post.create(title: 'Rspec test 3', text: 'rspec test for post', author_id: @first_user.id)
+    @post4 = Post.create(title: 'Rspec test 4', text: 'rspec test for post', author_id: @first_user.id)
   end
 
   describe 'User index page test' do

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -33,5 +33,35 @@ RSpec.feature "Users", type: :feature do
     end
   end
 
+  describe 'User show page test' do
+    scenario 'Should show the username ' do
+      visit user_path(@first_user)
+      expect(page).to have_content(@first_user.name)
+    end
+
+    scenario 'Should show the profile picture' do
+      visit user_path(@first_user)
+      expect(page).to have_selector("img[src='#{@first_user.photo}']")
+    end
+
+    scenario 'Should show the bio' do
+      visit user_path(@first_user)
+      expect(page).to have_content(@first_user.bio)
+    end
+
+    scenario 'Should show the list of three most recent posts' do
+      visit user_path(@first_user)
+      expect(page).to have_content(@post2.title)
+      expect(page).to have_content(@post3.title)
+      expect(page).to have_content(@post4.title)
+    end
+
+    scenario 'should redirect to post\'s page' do
+      visit user_path(@first_user)
+      click_on @post2.title
+      expect(page).to have_current_path(user_post_path(@first_user, @post2))
+    end
+  end
+
   
 end

--- a/spec/request/posts_spec.rb
+++ b/spec/request/posts_spec.rb
@@ -1,37 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe 'Posts', type: :request do
-  describe 'GET /posts' do
-    it 'return a success response' do
-      get('/users/1/posts')
-      expect(response).to have_http_status(200)
-    end
+  # describe 'GET /posts' do
+  #   it 'return a success response' do
+  #     get('/users/1/posts')
+  #     expect(response).to have_http_status(200)
+  #   end
 
-    it 'render the index template' do
-      get('/users/1/posts')
-      expect(response).to render_template(:index)
-    end
+  #   it 'render the index template' do
+  #     get('/users/1/posts')
+  #     expect(response).to render_template(:index)
+  #   end
 
-    it 'render the list of posts' do
-      get('/users/1/posts')
-      expect(response.body).to include('User 1 Posts List')
-    end
-  end
+  #   it 'render the list of posts' do
+  #     get('/users/1/posts')
+  #     expect(response.body).to include('User 1 Posts List')
+  #   end
+  # end
 
-  describe 'GET /posts/:id' do
-    it 'return a success response' do
-      get('/users/1/posts/1')
-      expect(response).to have_http_status(200)
-    end
+  # describe 'GET /posts/:id' do
+  #   it 'return a success response' do
+  #     get('/users/1/posts/1')
+  #     expect(response).to have_http_status(200)
+  #   end
 
-    it 'render the show template' do
-      get('/users/1/posts/1')
-      expect(response).to render_template(:show)
-    end
+  #   it 'render the show template' do
+  #     get('/users/1/posts/1')
+  #     expect(response).to render_template(:show)
+  #   end
 
-    it 'render the post' do
-      get('/users/1/posts/1')
-      expect(response.body).to include('Post 1 Details')
-    end
-  end
+  #   it 'render the post' do
+  #     get('/users/1/posts/1')
+  #     expect(response.body).to include('Post 1 Details')
+  #   end
+  # end
 end

--- a/spec/request/posts_spec.rb
+++ b/spec/request/posts_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Posts', type: :request do
 
     it 'render the list of posts' do
       get user_posts_path(@first_user.id)
-      expect(response.body).to include("User Posts")
+      expect(response.body).to include('User Posts')
     end
   end
 

--- a/spec/request/posts_spec.rb
+++ b/spec/request/posts_spec.rb
@@ -1,37 +1,44 @@
 require 'rails_helper'
 
 RSpec.describe 'Posts', type: :request do
-  # describe 'GET /posts' do
-  #   it 'return a success response' do
-  #     get('/users/1/posts')
-  #     expect(response).to have_http_status(200)
-  #   end
+  before(:all) do
+    @first_user = User.create(name: 'Integration test', photo: 'http://twitter.com', bio: 'test for User')
+    @post1 = Post.create(title: 'Rspec test 1', text: 'rspec test for post', author_id: @first_user.id)
+    @post2 = Post.create(title: 'Rspec test 2', text: 'rspec test for post', author_id: @first_user.id)
+    @post3 = Post.create(title: 'Rspec test 3', text: 'rspec test for post', author_id: @first_user.id)
+  end
 
-  #   it 'render the index template' do
-  #     get('/users/1/posts')
-  #     expect(response).to render_template(:index)
-  #   end
+  describe 'GET /posts' do
+    it 'return a success response' do
+      get user_posts_path(@first_user.id)
+      expect(response).to have_http_status(200)
+    end
 
-  #   it 'render the list of posts' do
-  #     get('/users/1/posts')
-  #     expect(response.body).to include('User 1 Posts List')
-  #   end
-  # end
+    it 'render the index template' do
+      get user_posts_path(@first_user.id)
+      expect(response).to render_template(:index)
+    end
 
-  # describe 'GET /posts/:id' do
-  #   it 'return a success response' do
-  #     get('/users/1/posts/1')
-  #     expect(response).to have_http_status(200)
-  #   end
+    it 'render the list of posts' do
+      get user_posts_path(@first_user.id)
+      expect(response.body).to include("User Posts")
+    end
+  end
 
-  #   it 'render the show template' do
-  #     get('/users/1/posts/1')
-  #     expect(response).to render_template(:show)
-  #   end
+  describe 'GET /posts/:id' do
+    it 'return a success response' do
+      get user_post_path(@first_user.id, @post1.id)
+      expect(response).to have_http_status(200)
+    end
 
-  #   it 'render the post' do
-  #     get('/users/1/posts/1')
-  #     expect(response.body).to include('Post 1 Details')
-  #   end
-  # end
+    it 'render the show template' do
+      get user_post_path(@first_user.id, @post1.id)
+      expect(response).to render_template(:show)
+    end
+
+    it 'render the post' do
+      get user_post_path(@first_user.id, @post1.id)
+      expect(response.body).to include("Post ##{@post1.id} Details")
+    end
+  end
 end

--- a/spec/request/users_spec.rb
+++ b/spec/request/users_spec.rb
@@ -18,20 +18,20 @@ RSpec.describe 'Users', type: :request do
     end
   end
 
-  describe 'GET #show' do
-    it 'returns a success response' do
-      get('/users/1')
-      expect(response).to have_http_status(200)
-    end
+  # describe 'GET #show' do
+  #   it 'returns a success response' do
+  #     get('/users/1')
+  #     expect(response).to have_http_status(200)
+  #   end
 
-    it 'renders the show template' do
-      get('/users/1')
-      expect(response).to render_template('show')
-    end
+  #   it 'renders the show template' do
+  #     get('/users/1')
+  #     expect(response).to render_template('show')
+  #   end
 
-    it 'renders the user' do
-      get('/users/1')
-      expect(response.body).to include('User Profile')
-    end
-  end
+  #   it 'renders the user' do
+  #     get('/users/1')
+  #     expect(response.body).to include('User Profile')
+  #   end
+  # end
 end

--- a/spec/request/users_spec.rb
+++ b/spec/request/users_spec.rb
@@ -1,6 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe 'Users', type: :request do
+  before(:all) do
+    @first_user = User.create(name: 'Integration test', photo: 'http://twitter.com', bio: 'test for User')
+    @post1 = Post.create(title: 'Rspec test 1', text: 'rspec test for post', author_id: @first_user.id)
+    @post2 = Post.create(title: 'Rspec test 2', text: 'rspec test for post', author_id: @first_user.id)
+    @post3 = Post.create(title: 'Rspec test 3', text: 'rspec test for post', author_id: @first_user.id)
+  end
+
   describe 'GET #index' do
     it 'returns a success response' do
       get users_path
@@ -18,20 +25,20 @@ RSpec.describe 'Users', type: :request do
     end
   end
 
-  # describe 'GET #show' do
-  #   it 'returns a success response' do
-  #     get('/users/1')
-  #     expect(response).to have_http_status(200)
-  #   end
+  describe 'GET #show' do
+    it 'returns a success response' do
+      get("/users/#{@first_user.id}")
+      expect(response).to have_http_status(200)
+    end
 
-  #   it 'renders the show template' do
-  #     get('/users/1')
-  #     expect(response).to render_template('show')
-  #   end
+    it 'renders the show template' do
+      get("/users/#{@first_user.id}")
+      expect(response).to render_template('show')
+    end
 
-  #   it 'renders the user' do
-  #     get('/users/1')
-  #     expect(response.body).to include('User Profile')
-  #   end
-  # end
+    it 'renders the user' do
+      get("/users/#{@first_user.id}")
+      expect(response.body).to include('User Profile')
+    end
+  end
 end


### PR DESCRIPTION
### In this pull request I have made some changes to my app controllers to solve n + 1 problems and write some tests for view files according to these requirements:

- n+1
  - Make sure that the N+1 problem is solved when fetching all posts and their comments for a user.
- Integration specs
  - Use Capybara to write integration tests for each view in your project.

- User index page:

  - I can see the username of all other users.
  - I can see the profile picture for each user.
  - I can see the number of posts each user has written.
  - When I click on a user, I am redirected to that user's show page.
  
- User show page:

  - I can see the user's profile picture.
  - I can see the user's username.
  - I can see the number of posts the user has written.
  - I can see the user's bio.
  - I can see the user's first 3 posts.
  - I can see a button that lets me view all of a user's posts.
  - When I click a user's post, it redirects me to that post's show page.
  - When I click to see all posts, it redirects me to the user's post's index page.

- User post index page:

  - I can see the user's profile picture.
  - I can see the user's username.
  - I can see the number of posts the user has written.
  - I can see a post's title.
  - I can see some of the post's body.
  - I can see the first comments on a post.
  - I can see how many comments a post has.
  - I can see how many likes a post has.
  - I can see a section for pagination if there are more posts than fit on the view.
  - When I click on a post, it redirects me to that post's show page.
  
- Post-show page:

  - I can see the post's title.
  - I can see who wrote the post.
  - I can see how many comments it has.
  - I can see how many likes it has.
  - I can see the post body.
  - I can see the username of each commenter.
  - I can see the comment each commenter left.